### PR TITLE
Reset encoder.seq before use

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -659,6 +659,7 @@ func (enc *Encoder) Encode(w io.Writer, a APNG) error {
 	e.enc = enc
 	e.w = w
 	e.a = a
+	e.seq = 0
 
 	var pal color.Palette
 	// cbP8 encoding needs PalettedImage's ColorIndexAt method.


### PR DESCRIPTION
Due to the use of the Encoder.BufferPool, encoder.seq must be reset.